### PR TITLE
Updated client code

### DIFF
--- a/shared/src/main/scala/frankenpaxos/raft/Client.scala
+++ b/shared/src/main/scala/frankenpaxos/raft/Client.scala
@@ -1,10 +1,10 @@
 package frankenpaxos.raft
 
-import frankenpaxos.Actor
-import frankenpaxos.Logger
-import frankenpaxos.ProtoSerializer
-import frankenpaxos.Chan
+import frankenpaxos.{Actor, Chan, Logger, ProtoSerializer}
+import scala.concurrent.{Future, Promise}
 import scala.scalajs.js.annotation._
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 @JSExportAll
 object ClientInboundSerializer extends ProtoSerializer[ClientInbound] {
@@ -32,73 +32,160 @@ class Client[Transport <: frankenpaxos.Transport[Transport]](
   // The set of raft nodes.
   val raftParticipants: Seq[Chan[Participant[Transport]]] =
     for (participantAddress <- config.participantAddresses)
-      yield
-        chan[Participant[Transport]](
-          participantAddress,
-          Participant.serializer
-        )
+      yield chan[Participant[Transport]](
+        participantAddress,
+        Participant.serializer
+      )
 
   // index of presumed leader
   var leaderIndex = 0
 
+  // pending action - No need for lock since client acts synchronously
+  @JSExportAll
+  sealed trait PendingState
+
+  @JSExportAll
+  case class PendingWrite(
+      promise: Promise[Boolean],
+      cmd: String
+  ) extends PendingState
+
+  @JSExportAll
+  case class PendingRead(
+      promise: Promise[String],
+      index: Integer
+  ) extends PendingState
+
+  var pending: Option[PendingState] = None
+
   logger.info(s"Raft client listening on $srcAddress.")
 
-  override def receive(src: Transport#Address, inbound: InboundMessage): Unit = {
+  override def receive(
+      src: Transport#Address,
+      inbound: InboundMessage
+  ): Unit = {
     import ClientInbound.Request
     inbound.request match {
-      case Request.WriteCmdResponse(r) => handleWriteCommandResponse(src, r)
-      case Request.ReadCmdResponse(r)  => handleReadCommandResponse(src, r)
+      case Request.ClientRequestResponse(r) =>
+        handleClientRequestResponse(src, r)
+      case Request.ClientQueryResponse(r) => handleClientQueryResponse(src, r)
       case Request.Empty => {
         logger.fatal("Empty ClientInbound encountered.")
       }
     }
   }
 
-  private def handleWriteCommandResponse(src: Transport#Address, cmdRes: WriteCommandResponse) {
-    logger.info(s"Got WriteCommandResponse from ${src}" 
-                + s"| Success: ${cmdRes.success}"
-                + s"| LeaderIndex: ${cmdRes.leaderIndex}"
-                + s"| Command: ${cmdRes.cmd}"
-                + s"| LogIndex: ${cmdRes.index}")
-            
-    if (!cmdRes.success) {
-        leaderIndex = cmdRes.leaderIndex
-        logger.info(s"$src is not leader, trying again with ${raftParticipants(leaderIndex).dst}.")
-        writeCommand(cmdRes.cmd)
-    } else {
-      logger.info(s"Command succussfully replicated!")
+  // Helpers
+
+  private def handleClientRequestResponse(
+      src: Transport#Address,
+      requestResponse: ClientRequestResponse
+  ) {
+    logger.info(
+      s"Got ClientRequestResponse from ${src}"
+        + s"| Success: ${requestResponse.success}"
+        + s"| Response: ${requestResponse.response}"
+        + s"| Leader Hint: ${requestResponse.leaderHint}"
+    )
+    pending match {
+      case Some(pendingWrite: PendingWrite) =>
+        if (!requestResponse.success) {
+          if (requestResponse.response == "NOT_LEADER") {
+            leaderIndex = requestResponse.leaderHint
+            logger.info(
+              s"$src is not leader, trying again with ${raftParticipants(leaderIndex).dst}."
+            )
+            write(pendingWrite.cmd)
+          }
+        } else {
+          logger.info("Command successfully replicated!")
+          pendingWrite.promise.success(true)
+          pending = None
+        }
+      case Some(_: PendingRead) =>
+        logger.error("Request response received while no pending read exists.")
+      case None =>
+        logger.error(
+          "Request response received while no pending action exists."
+        )
     }
   }
 
-  private def handleReadCommandResponse(src: Transport#Address, cmdRes: ReadCommandResponse) {
-    logger.info(s"Got ReadCommandResponse from ${src}" 
-                + s"| Success: ${cmdRes.success}"
-                + s"| LeaderIndex: ${cmdRes.leaderIndex}"
-                + s"| Command: ${cmdRes.cmd}"
-                + s"| LogIndex: ${cmdRes.index}")
-            
-    if (!cmdRes.success) {
-        leaderIndex = cmdRes.leaderIndex
-        logger.info(s"$src is not leader, trying again with ${raftParticipants(leaderIndex).dst}.")
-        readCommand(cmdRes.index)
-    } else {
-      logger.info(s"Read command successfully!")
+  private def handleClientQueryResponse(
+      src: Transport#Address,
+      queryResponse: ClientQueryResponse
+  ) {
+    logger.info(
+      s"Got ClientQueryResponse from ${src}"
+        + s"| Success: ${queryResponse.success}"
+        + s"| Response: ${queryResponse.response}"
+        + s"| Leader Hint: ${queryResponse.leaderHint}"
+    )
+    pending match {
+      case Some(pendingWrite: PendingWrite) =>
+        logger.error("Request response received while no pending write exists.")
+      case Some(pendingRead: PendingRead) =>
+        if (!queryResponse.success) {
+          if (queryResponse.response == "NOT_LEADER") {
+            leaderIndex = queryResponse.leaderHint
+            logger.info(
+              s"$src is not leader, trying again with ${raftParticipants(leaderIndex).dst}."
+            )
+            read(pendingRead.index)
+          }
+        } else {
+          logger.info("Command successfully replicated!")
+          pendingRead.promise.success(queryResponse.response)
+          pending = None
+        }
+      case None =>
+        logger.error(
+          "Request response received while no pending action exists."
+        )
     }
   }
 
-  private def writeCommandImpl(cmd: String): Unit = {
-    raftParticipants(leaderIndex).send(ParticipantInbound().withWriteCmdRequest(WriteCommandRequest(cmd = cmd)))
+  private def writeImpl(cmd: String): Unit = {
+    raftParticipants(leaderIndex).send(
+      ParticipantInbound().withClientRequest(ClientRequest(cmd = cmd))
+    )
   }
 
-  private def readCommandImpl(index: Int): Unit = {
-    raftParticipants(leaderIndex).send(ParticipantInbound().withReadCmdRequest(ReadCommandRequest(index = index)))
+  private def readImpl(index: Int): Unit = {
+    raftParticipants(leaderIndex).send(
+      ParticipantInbound().withClientQuery(ClientQuery(index = index))
+    )
   }
 
-  def writeCommand(cmd: String): Unit = {
-    transport.executionContext().execute(() => writeCommandImpl(cmd))
+  // Interface
+
+  def write(cmd: String): Future[Boolean] = {
+    if (pending != None) {
+      throw new Exception("An action is already pending!")
+    }
+    val promise = Promise[Boolean]()
+    pending = Some(
+      PendingWrite(
+        promise = promise,
+        cmd = cmd
+      )
+    )
+    transport.executionContext().execute(() => writeImpl(cmd))
+    promise.future
   }
 
-  def readCommand(index: Int): Unit = {
-    transport.executionContext().execute(() => readCommandImpl(index))
+  def read(index: Int): Future[String] = {
+    if (pending != None) {
+      throw new Exception("An action is already pending!")
+    }
+    val promise = Promise[String]()
+    pending = Some(
+      PendingRead(
+        promise = promise,
+        index = index
+      )
+    )
+    transport.executionContext().execute(() => readImpl(index))
+    promise.future
   }
 }

--- a/shared/src/main/scala/frankenpaxos/raft/Raft.proto
+++ b/shared/src/main/scala/frankenpaxos/raft/Raft.proto
@@ -9,6 +9,8 @@ option (scalapb.options) = {
   flat_package: true
 };
 
+// Participant Requests
+
 message VoteRequest {
   required int32 term = 1;
   required int32 last_log_index = 2;
@@ -39,27 +41,31 @@ message AppendEntriesResponse {
   required int32 last_log_index = 3;
 }
 
-message WriteCommandRequest {
+// Client Requests
+
+message ClientRequest {
+  // required int32 client_id = 1;
+  // required int32 sequence_num = 1; for eliminating duplicates
   required string cmd = 1;
 }
 
-message WriteCommandResponse {
+message ClientRequestResponse {
   required bool success = 1;
-  required int32 leader_index = 2;
-  required string cmd = 3;
-  required int32 index = 4;
+  required string response = 2;
+  required int32 leader_hint = 3;
 }
 
-message ReadCommandRequest {
+message ClientQuery {
   required int32 index = 1;
 }
 
-message ReadCommandResponse {
+message ClientQueryResponse {
   required bool success = 1;
-  required int32 leader_index = 2;
-  required string cmd = 3;
-  required int32 index = 4;
+  required string response = 2;
+  required int32 leader_hint = 3;
 }
+
+// Expected messages to recieve
 
 message ParticipantInbound {
   oneof request {
@@ -67,14 +73,14 @@ message ParticipantInbound {
     VoteResponse vote_response = 2;
     AppendEntriesRequest append_entries_request = 3;
     AppendEntriesResponse append_entries_response = 4;
-    WriteCommandRequest write_cmd_request = 5;
-    ReadCommandRequest read_cmd_request = 6;
+    ClientRequest client_request = 5;
+    ClientQuery client_query = 6;
   }
 }
 
 message ClientInbound {
   oneof request {
-    WriteCommandResponse write_cmd_response = 1;
-    ReadCommandResponse read_cmd_response = 2;
+    ClientRequestResponse client_request_response = 1;
+    ClientQueryResponse client_query_response = 2;
   }
 }


### PR DESCRIPTION
I ended up going with a simple approach, allowing clients only one operation at a time, which we may have to change if not appropriate. I also changed some of the naming conventions in the protobufs to make them more similar to what is specified [here](https://web.stanford.edu/~ouster/cgi-bin/papers/OngaroPhD.pdf). I think we don't have to implement client sessions because we are assuming that clients stay down if they crash (like in Michael's Paxos approaches, and thus no duplicate messages either, which would have been a whole lot more headache. Next up is making sure this all works, so I'll have to tinker with the frontend.